### PR TITLE
remove stray unmatched bracket

### DIFF
--- a/MetaData/python/JobConfig.py
+++ b/MetaData/python/JobConfig.py
@@ -259,7 +259,6 @@ class JobConfig(object):
                             puObj.puReWeight = True
                             puObj.puBins = cms.vdouble( map(float, samplepu.probFunctionVariable) )
                             puObj.mcPu   = samplepu.probValue
-                            ]
                             puObj.dataPu = cms.vdouble(putarget)
                             puObj.useTruePu = cms.bool(True)
                         


### PR DESCRIPTION
I think this is a bug; at least, it fails python compilation and it doesn't look right.
